### PR TITLE
Fixed bug: Response

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ python3 main.py
 ## Known Issues
 - **API Rate Limiting**: Extensive use of the Reddit API, especially during development and testing, can lead to hitting the rate limits imposed by Reddit. This can temporarily block the bot from accessing Reddit data.
 - **Subreddit Accessibility**: The bot may encounter issues if it tries to access a subreddit that is private, restricted, or banned.
-  - It also might get flagged for spamming (I've gottne banned multiple times...)
+  - It also might get flagged for spamming (I've gotten banned multiple times...)
   - I found that it works best on a subreddit owned by the bot's reddit acccount, but it does work on other subreddits. Just be warned, your bot might get shadowbanned. 
 - **Unit Conversion Limitations**: The bot currently handles a predefined set of metric units. It may not recognize or correctly convert units that are not explicitly defined in its configuration.
   - The main units that it recognizes (in most both abbreviated and non-abbreviated formats) are: 

--- a/main.py
+++ b/main.py
@@ -4,7 +4,8 @@ load_dotenv()
 from reddit_bot import RedditBot
 
 def main():
-    subreddit_names = ["pleasedontbanmedebug", "rlydontbanmedebug"]
+    # Add the list of subreddits you'd like to add here
+    subreddit_names = ["thelastdebuggernoban", "lastsubredditdebugger"]
     bot = RedditBot(subreddit_names)
     bot.start_streaming()
 

--- a/reddit_bot.py
+++ b/reddit_bot.py
@@ -15,6 +15,7 @@ class RedditBot:
             password=os.getenv("REDDIT_PASSWORD")
         )
         self.subreddits = [self.reddit.subreddit(name) for name in subreddit_names]
+        self.bot_username = os.getenv("REDDIT_USERNAME")
         self.ureg = UnitRegistry()
         self.lhm = LikeHowMuch()
 
@@ -77,6 +78,9 @@ class RedditBot:
             self.process_comment(comment)
 
     def process_comment(self, comment):
+        if comment.author.name == self.bot_username:
+            return
+
         metric_units = self.detect_metric(comment.body)
         imperial_units = self.detect_imperial(comment.body)
 


### PR DESCRIPTION
Since the bot monitors all new comments, I need to ensure that it only responds to comments by different authors. What happened was that it would post a response, then read that response it just posted, and then respond to that post. This would go on like an infinite look until reddit bans the account.